### PR TITLE
Add missing requirements to requirements.txt and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You will need the following whether you plan to use the toolbox only or to retra
 
 **Python 3.7**. Python 3.6 might work too, but I wouldn't go lower because I make extensive use of pathlib.
 
-Run `pip -r requirements.txt` to install the necessary packages. Additionally you will need [PyTorch](https://pytorch.org/get-started/locally/) and PyQt4 (Linux: package `python-qt4`, [Windows](https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyqt4))	
+Run `pip -r requirements.txt` to install the necessary packages. Additionally you will need [PyTorch](https://pytorch.org/get-started/locally/), PyQt4 (Linux: package `python-qt4`, [Windows](https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyqt4)) and [PyAudio](https://people.csail.mit.edu/hubert/pyaudio/).
 
 A GPU is *highly* recommended (CPU-only is currently not implemented), but you don't necessarily need a high tier GPU if you only want to use the toolbox.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ numpy>=1.14.0
 scipy>=1.0.0
 tqdm
 sounddevice
+Unidecode
+inflect


### PR DESCRIPTION
First of all, great work on this amazing project @CorentinJ ✨ !

I noticed a few requirements seemed to be missing: `Unidecode`, `inflect` and `PyAudio`. I added the former 2 into `requirements.txt`. I left `PyAudio` out - since it depends on native code, it might need additional installation steps or be easier to install without pip (I installed it with Conda) - so I just added a note to the README.