### PR TITLE
Upgrade to PyQt5, switch to plain textarea for synthesis input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You will need the following whether you plan to use the toolbox only or to retra
 
 **Python 3.7**. Python 3.6 might work too, but I wouldn't go lower because I make extensive use of pathlib.
 
-Run `pip -r requirements.txt` to install the necessary packages. Additionally you will need [PyTorch](https://pytorch.org/get-started/locally/) and PyQt4 (Linux: package `python-qt4`, [Windows](https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyqt4))	
+Run `pip -r requirements.txt` to install the necessary packages. Additionally you will need [PyTorch](https://pytorch.org/get-started/locally/) and [PyQt5](https://www.riverbankcomputing.com/software/pyqt/intro).	
 
 A GPU is *highly* recommended (CPU-only is currently not implemented), but you don't necessarily need a high tier GPU if you only want to use the toolbox.
 

--- a/demo_toolbox.py
+++ b/demo_toolbox.py
@@ -3,8 +3,16 @@ from toolbox import Toolbox
 from utils.argutils import print_args
 import argparse
 
+import sys
+import traceback
+
+def excepthook(exc_type, exc_value, exc_tb):
+    traceback.print_exception(exc_type, exc_value, exc_tb)
+    sys.exit(1)
 
 if __name__ == '__main__':
+    sys.excepthook = excepthook
+
     parser = argparse.ArgumentParser(
         description="Runs the toolbox",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter

--- a/toolbox/ui.py
+++ b/toolbox/ui.py
@@ -1,7 +1,7 @@
-from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
-from PyQt4.QtCore import Qt
-from PyQt4.QtGui import *
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import *
 from encoder.inference import plot_embedding_as_heatmap
 from toolbox.utterance import Utterance
 from pathlib import Path
@@ -43,8 +43,8 @@ default_text = \
     "Each line will be treated separately.\nThen, they are joined together to make the final " \
     "spectrogram. Use the vocoder to generate audio.\nThe vocoder generates almost in constant " \
     "time, so it will be more time efficient for longer inputs like this one.\nOn the left you " \
-    "have the embedding projections. Load or record more utterances to see them.\n If you have " \
-    "at least 2 or 3 utterances from a same speaker, a cluster should form.\n Synthesized " \
+    "have the embedding projections. Load or record more utterances to see them.\nIf you have " \
+    "at least 2 or 3 utterances from a same speaker, a cluster should form.\nSynthesized " \
     "utterances are of the same color as the speaker whose voice was used, but they're " \
     "represented with a cross."
 
@@ -456,7 +456,7 @@ class UI(QDialog):
         
         
         ## Generation
-        self.text_prompt = QTextEdit(default_text.replace("\n", "<br>"))
+        self.text_prompt = QPlainTextEdit(default_text)
         gen_layout.addWidget(self.text_prompt, stretch=1)
         
         self.generate_button = QPushButton("Synthesize and vocode")


### PR DESCRIPTION
[Apparently](https://www.riverbankcomputing.com/software/pyqt/intro) PyQt4 isn't the best choice for new projects:

> PyQt4 and Qt v4 are no longer supported and no new releases will be made. PyQt5 and Qt v5 are strongly recommended for all new development.

and it seems to have some [potential compatibility problems](https://stackoverflow.com/questions/53699190/installing-pyqt4-on-python-3-7) with Python 3.7.

I made a few tweaks to port it over to PyQt5, it all seems to work smoothly. I also switched from `QTextEdit` to `QPlainTextEdit`, which prevents styling being copied over from pasted text ☺️ .