### PR TITLE
Simplify with s in tuple

### DIFF
--- a/synthesizer/utils/text.py
+++ b/synthesizer/utils/text.py
@@ -71,4 +71,4 @@ def _arpabet_to_sequence(text):
 
 
 def _should_keep_symbol(s):
-  return s in _symbol_to_id and s is not "_" and s is not "~"
+  return s in _symbol_to_id and s not in ("_", "~")


### PR DESCRIPTION
This simplification also gets around two identity vs. equality issues that flake8 flagged below.

[flake8](http://flake8.pycqa.org) testing of https://github.com/CorentinJ/Real-Time-Voice-Cloning on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./synthesizer/synthesize.py:110:9: F821 undefined name 'run_live'
        run_live(args, checkpoint_path, hparams)
        ^
./synthesizer/train.py:347:46: F821 undefined name 'linear_dir'
                        np.save(os.path.join(linear_dir, linear_filename), linear_prediction.T,
                                             ^
./synthesizer/utils/text.py:74:33: F632 use ==/!= to compare str, bytes, and int literals
  return s in _symbol_to_id and s is not "_" and s is not "~"
                                ^
./synthesizer/utils/text.py:74:50: F632 use ==/!= to compare str, bytes, and int literals
  return s in _symbol_to_id and s is not "_" and s is not "~"
                                                 ^
2     F632 use ==/!= to compare str, bytes, and int literals
2     F821 undefined name 'run_live'
4
```