### PR TITLE
Fixing "'ascii' codec can't encode characters in position 52-67" bug

### DIFF
--- a/vocoder/display.py
+++ b/vocoder/display.py
@@ -13,7 +13,7 @@ def progbar(i, n, size=16):
 
 
 def stream(message) :
-    sys.stdout.write("\r{%s}" % message)
+    sys.stdout.write("\r{%s}" % message.encode('utf-8').strip())
 
 
 def simple_table(item_tuples) :


### PR DESCRIPTION
```
  File "demo_cli.py", line 161, in <module>
    generated_wav = vocoder.infer_waveform(spec)
  File "/workspace/Real-Time-Voice-Cloning/vocoder/inference.py", line 57, in infer_waveform
    wav = _model.generate(mel, batched, target, overlap, hp.mu_law, progress_callback)
  File "/workspace/Real-Time-Voice-Cloning/vocoder/models/fatchord_version.py", line 219, in generate
    progress_callback(i, seq_len, b_size, gen_rate)
  File "/workspace/Real-Time-Voice-Cloning/vocoder/models/fatchord_version.py", line 248, in gen_display
    stream(msg)
  File "/workspace/Real-Time-Voice-Cloning/vocoder/display.py", line 16, in stream
    sys.stdout.write("\r{%s}" % message)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 4-19: ordinal not in range(128)
 
During handling of the above exception, another exception occurred:
 
Traceback (most recent call last):
  File "demo_cli.py", line 184, in <module>
    print("Caught exception: %s" % repr(e))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 52-67: ordinal not in range(128)
```