### PR TITLE
optimize volume normalization

### DIFF
--- a/encoder/audio.py
+++ b/encoder/audio.py
@@ -95,7 +95,7 @@ def trim_long_silences(wav):
     audio_mask = binary_dilation(audio_mask, np.ones(vad_max_silence_length + 1))
     audio_mask = np.repeat(audio_mask, samples_per_window)
     
-    return wav[audio_mask]
+    return wav[audio_mask == True]
 
 
 def normalize_volume(wav, target_dBFS, increase_only=False, decrease_only=False):

--- a/encoder/audio.py
+++ b/encoder/audio.py
@@ -101,9 +101,7 @@ def trim_long_silences(wav):
 def normalize_volume(wav, target_dBFS, increase_only=False, decrease_only=False):
     if increase_only and decrease_only:
         raise ValueError("Both increase only and decrease only are set")
-    rms = np.mean(wav ** 2)
-    wave_dBFS = 10 * np.log10(rms)
-    dBFS_change = target_dBFS - wave_dBFS
+    dBFS_change = target_dBFS - 10 * np.log10(np.mean(wav ** 2))
     if (dBFS_change < 0 and increase_only) or (dBFS_change > 0 and decrease_only):
         return wav
     return wav * (10 ** (dBFS_change / 20))

--- a/encoder/audio.py
+++ b/encoder/audio.py
@@ -95,15 +95,15 @@ def trim_long_silences(wav):
     audio_mask = binary_dilation(audio_mask, np.ones(vad_max_silence_length + 1))
     audio_mask = np.repeat(audio_mask, samples_per_window)
     
-    return wav[audio_mask == True]
+    return wav[audio_mask]
 
 
 def normalize_volume(wav, target_dBFS, increase_only=False, decrease_only=False):
     if increase_only and decrease_only:
         raise ValueError("Both increase only and decrease only are set")
-    rms = np.sqrt(np.mean((wav * int16_max) ** 2))
-    wave_dBFS = 20 * np.log10(rms / int16_max)
+    rms = np.mean(wav ** 2)
+    wave_dBFS = 10 * np.log10(rms)
     dBFS_change = target_dBFS - wave_dBFS
-    if dBFS_change < 0 and increase_only or dBFS_change > 0 and decrease_only:
+    if (dBFS_change < 0 and increase_only) or (dBFS_change > 0 and decrease_only):
         return wav
     return wav * (10 ** (dBFS_change / 20))


### PR DESCRIPTION
fix a logical bug, missing parentheses.
Optimization:
20 * log10(sqrt(np.mean((wav * max_possible_amplitude)^2)) / max_possible_amplitude)
= 20 * log10(sqrt(max_possible_amplitude^2 * np.mean(wav^2)) / max_possible_amplitude)
= 20 * log10(max_possible_amplitude * sqrt(np.mean(wav^2)) / max_possible_amplitude)
= 20 * log10(sqrt(np.mean(wav^2)))
= 10 * log10(np.mean(wav^2))