### PR TITLE
Convert pathlib objects to str when used as argument to librosa.load()

### DIFF
--- a/demo_cli.py
+++ b/demo_cli.py
@@ -135,7 +135,7 @@ if __name__ == '__main__':
             # - Directly load from the filepath:
             preprocessed_wav = encoder.preprocess_wav(in_fpath)
             # - If the wav is already loaded:
-            original_wav, sampling_rate = librosa.load(in_fpath)
+            original_wav, sampling_rate = librosa.load(str(in_fpath))
             preprocessed_wav = encoder.preprocess_wav(original_wav, sampling_rate)
             print("Loaded file succesfully")
             

--- a/encoder/audio.py
+++ b/encoder/audio.py
@@ -25,7 +25,7 @@ def preprocess_wav(fpath_or_wav: Union[str, Path, np.ndarray],
     """
     # Load the wav from disk if needed
     if isinstance(fpath_or_wav, str) or isinstance(fpath_or_wav, Path):
-        wav, source_sr = librosa.load(fpath_or_wav, sr=None)
+        wav, source_sr = librosa.load(str(fpath_or_wav), sr=None)
     else:
         wav = fpath_or_wav
     

--- a/synthesizer/inference.py
+++ b/synthesizer/inference.py
@@ -108,7 +108,7 @@ class Synthesizer:
         Loads and preprocesses an audio file under the same conditions the audio files were used to
         train the synthesizer. 
         """
-        wav = librosa.load(fpath, hparams.sample_rate)[0]
+        wav = librosa.load(str(fpath), hparams.sample_rate)[0]
         if hparams.rescale:
             wav = wav / np.abs(wav).max() * hparams.rescaling_max
         return wav

--- a/synthesizer/preprocess.py
+++ b/synthesizer/preprocess.py
@@ -82,7 +82,7 @@ def preprocess_speaker(speaker_dir, out_dir: Path, skip_existing: bool, hparams)
 
 def split_on_silences(wav_fpath, words, end_times, hparams):
     # Load the audio waveform
-    wav, _ = librosa.load(wav_fpath, hparams.sample_rate)
+    wav, _ = librosa.load(str(wav_fpath), hparams.sample_rate)
     if hparams.rescale:
         wav = wav / np.abs(wav).max() * hparams.rescaling_max
     

--- a/vocoder/audio.py
+++ b/vocoder/audio.py
@@ -16,7 +16,7 @@ def float_2_label(x, bits) :
 
 
 def load_wav(path) :
-    return librosa.load(path, sr=hp.sample_rate)[0]
+    return librosa.load(str(path), sr=hp.sample_rate)[0]
 
 
 def save_wav(x, path) :


### PR DESCRIPTION
Newer versions of librosa>=0.7.0 do not accept a pathlib object for librosa.load()

This will break demo_cli.py among other things. There was a fix for this in #331 but was not implemented because since it went too far in removing existing usage of pathlib.