### PR TITLE
Add progress bar exception for systems that do not support unicode

### DIFF
--- a/vocoder/display.py
+++ b/vocoder/display.py
@@ -13,7 +13,12 @@ def progbar(i, n, size=16):
 
 
 def stream(message) :
-    sys.stdout.write("\r{%s}" % message)
+    try:
+        sys.stdout.write("\r{%s}" % message)
+    except:
+        #Remove non-ASCII characters from message
+        message = ''.join(i for i in message if ord(i)<128)
+        sys.stdout.write("\r{%s}" % message)
 
 
 def simple_table(item_tuples) :


### PR DESCRIPTION
This will resolve #50 and #89 by removing non-ascii characters from the progress bar on systems which do not support them in stdout. While the vocoder is synthesizing output will look like this:

```
Created the mel spectrogram
Synthesizing the waveform:
{|  14300/124800 | Batch Size: 13 | Gen Rate: 1.6kHz | }
```

Behavior is unchanged for systems which do support unicode. These users will continue to see the progress bar.