### PR TITLE
Fixed error "No module named 'numba.decorators'" after requirements install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ Unidecode
 inflect
 PyQt5
 multiprocess
-numba
+numba==0.48


### PR DESCRIPTION
After successfully installing `requirements.txt`, running the toolbox presents the user with an error `"ModuleNotFoundError: No module named 'numba.decorators'`. This is solved by using version 0.48 instead of the later versions, currently 0.50. This is because the latest version of numba removed the decorators module.