### PR TITLE
Skip trim_long_silences in preprocess_wav if webrtcvad not available

### DIFF
--- a/encoder/audio.py
+++ b/encoder/audio.py
@@ -2,6 +2,7 @@ from scipy.ndimage.morphology import binary_dilation
 from encoder.params_data import *
 from pathlib import Path
 from typing import Optional, Union
+from warnings import warn
 import numpy as np
 import librosa
 import struct
@@ -9,7 +10,7 @@ import struct
 try:
     import webrtcvad
 except:
-    print("WARNING: Unable to import 'webrtcvad'. Please install for better noise removal.")
+    warn("Unable to import 'webrtcvad'. This package enables noise removal and is recommended.")
     webrtcvad=None
 
 int16_max = (2 ** 15) - 1

--- a/encoder/audio.py
+++ b/encoder/audio.py
@@ -5,10 +5,12 @@ from typing import Optional, Union
 import numpy as np
 import librosa
 import struct
+import warnings
 
 try:
     import webrtcvad
 except:
+    print("WARNING: Unable to import 'webrtcvad'. Please install for better noise removal.")
     webrtcvad=None
 
 int16_max = (2 ** 15) - 1

--- a/encoder/audio.py
+++ b/encoder/audio.py
@@ -3,9 +3,13 @@ from encoder.params_data import *
 from pathlib import Path
 from typing import Optional, Union
 import numpy as np
-import webrtcvad
 import librosa
 import struct
+
+try:
+    import webrtcvad
+except:
+    webrtcvad=None
 
 int16_max = (2 ** 15) - 1
 
@@ -35,7 +39,8 @@ def preprocess_wav(fpath_or_wav: Union[str, Path, np.ndarray],
         
     # Apply the preprocessing: normalize volume and shorten long silences 
     wav = normalize_volume(wav, audio_norm_target_dBFS, increase_only=True)
-    wav = trim_long_silences(wav)
+    if webrtcvad:
+        wav = trim_long_silences(wav)
     
     return wav
 

--- a/encoder/audio.py
+++ b/encoder/audio.py
@@ -5,7 +5,6 @@ from typing import Optional, Union
 import numpy as np
 import librosa
 import struct
-import warnings
 
 try:
     import webrtcvad

--- a/encoder_preprocess.py
+++ b/encoder_preprocess.py
@@ -36,19 +36,19 @@ if __name__ == "__main__":
     parser.add_argument("-s", "--skip_existing", action="store_true", help=\
         "Whether to skip existing output files with the same name. Useful if this script was "
         "interrupted.")
-    parser.add_argument("--disable_webrtcvad_check", action="store_true", help=\
-        "Preprocess audio without the webrtcvad package installed (not recommended).")
+    parser.add_argument("--no_trim", action="store_true", help=\
+        "Preprocess audio without trimming silences (not recommended).")
     args = parser.parse_args()
 
     # Verify webrtcvad is available
-    if not args.disable_webrtcvad_check:
+    if not args.no_trim:
         try:
             import webrtcvad
         except:
             raise ModuleNotFoundError("Package 'webrtcvad' not found. This package enables "
                 "noise removal and is recommended. Please install and try again. If installation fails, "
-                "skip this check with --disable_webrtcvad_check")
-    del args.disable_webrtcvad_check
+                "use --no_trim to disable this error message.")
+    del args.no_trim
 
     # Process the arguments
     args.datasets = args.datasets.split(",")

--- a/encoder_preprocess.py
+++ b/encoder_preprocess.py
@@ -3,7 +3,6 @@ from utils.argutils import print_args
 from pathlib import Path
 import argparse
 
-
 if __name__ == "__main__":
     class MyFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
         pass
@@ -37,7 +36,19 @@ if __name__ == "__main__":
     parser.add_argument("-s", "--skip_existing", action="store_true", help=\
         "Whether to skip existing output files with the same name. Useful if this script was "
         "interrupted.")
+    parser.add_argument("--disable_webrtcvad_check", action="store_true", help=\
+        "Preprocess audio without the webrtcvad package installed (not recommended).")
     args = parser.parse_args()
+
+    # Verify webrtcvad is available
+    if not args.disable_webrtcvad_check:
+        try:
+            import webrtcvad
+        except:
+            raise ModuleNotFoundError("Package 'webrtcvad' not found. This package enables "
+                "noise removal and is recommended. Please install and try again. If installation fails, "
+                "skip this check with --disable_webrtcvad_check")
+    del args.disable_webrtcvad_check
 
     # Process the arguments
     args.datasets = args.datasets.split(",")
@@ -45,7 +56,7 @@ if __name__ == "__main__":
         args.out_dir = args.datasets_root.joinpath("SV2TTS", "encoder")
     assert args.datasets_root.exists()
     args.out_dir.mkdir(exist_ok=True, parents=True)
-    
+
     # Preprocess the datasets
     print_args(args, parser)
     preprocess_func = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ tensorflow-cpu==1.15
 tensorflow-gpu==1.15
 umap-learn
 visdom
-webrtcvad
 librosa>=0.5.1
 matplotlib>=2.0.2
 numpy>=1.14.0

--- a/synthesizer_preprocess_audio.py
+++ b/synthesizer_preprocess_audio.py
@@ -24,8 +24,8 @@ if __name__ == "__main__":
         "interrupted.")
     parser.add_argument("--hparams", type=str, default="", help=\
         "Hyperparameter overrides as a comma-separated list of name-value pairs")
-    parser.add_argument("--disable_webrtcvad_check", action="store_true", help=\
-        "Preprocess audio without the webrtcvad package installed (not recommended).")
+    parser.add_argument("--no_trim", action="store_true", help=\
+        "Preprocess audio without trimming silences (not recommended).")
     args = parser.parse_args()
 
     # Process the arguments
@@ -37,14 +37,14 @@ if __name__ == "__main__":
     args.out_dir.mkdir(exist_ok=True, parents=True)
 
     # Verify webrtcvad is available
-    if not args.disable_webrtcvad_check:
+    if not args.no_trim:
         try:
             import webrtcvad
         except:
             raise ModuleNotFoundError("Package 'webrtcvad' not found. This package enables "
                 "noise removal and is recommended. Please install and try again. If installation fails, "
-                "skip this check with --disable_webrtcvad_check")
-    del args.disable_webrtcvad_check
+                "use --no_trim to disable this error message.")
+    del args.no_trim
 
     # Preprocess the dataset
     print_args(args, parser)

--- a/synthesizer_preprocess_audio.py
+++ b/synthesizer_preprocess_audio.py
@@ -24,8 +24,10 @@ if __name__ == "__main__":
         "interrupted.")
     parser.add_argument("--hparams", type=str, default="", help=\
         "Hyperparameter overrides as a comma-separated list of name-value pairs")
+    parser.add_argument("--disable_webrtcvad_check", action="store_true", help=\
+        "Preprocess audio without the webrtcvad package installed (not recommended).")
     args = parser.parse_args()
-    
+
     # Process the arguments
     if not hasattr(args, "out_dir"):
         args.out_dir = args.datasets_root.joinpath("SV2TTS", "synthesizer")
@@ -33,6 +35,16 @@ if __name__ == "__main__":
     # Create directories
     assert args.datasets_root.exists()
     args.out_dir.mkdir(exist_ok=True, parents=True)
+
+    # Verify webrtcvad is available
+    if not args.disable_webrtcvad_check:
+        try:
+            import webrtcvad
+        except:
+            raise ModuleNotFoundError("Package 'webrtcvad' not found. This package enables "
+                "noise removal and is recommended. Please install and try again. If installation fails, "
+                "skip this check with --disable_webrtcvad_check")
+    del args.disable_webrtcvad_check
 
     # Preprocess the dataset
     print_args(args, parser)

--- a/vocoder_preprocess.py
+++ b/vocoder_preprocess.py
@@ -28,8 +28,8 @@ if __name__ == "__main__":
     parser.add_argument("--hparams", default="",
                         help="Hyperparameter overrides as a comma-separated list of name=value "
                              "pairs")
-    parser.add_argument("--disable_webrtcvad_check", action="store_true", help=\
-        "Preprocess audio without the webrtcvad package installed (not recommended).")
+    parser.add_argument("--no_trim", action="store_true", help=\
+        "Preprocess audio without trimming silences (not recommended).")
     args = parser.parse_args()
     print_args(args, parser)
     modified_hp = hparams.parse(args.hparams)
@@ -40,14 +40,14 @@ if __name__ == "__main__":
         args.out_dir = os.path.join(args.datasets_root, "SV2TTS", "vocoder")
     
     # Verify webrtcvad is available
-    if not args.disable_webrtcvad_check:
+    if not args.no_trim:
         try:
             import webrtcvad
         except:
             raise ModuleNotFoundError("Package 'webrtcvad' not found. This package enables "
                 "noise removal and is recommended. Please install and try again. If installation fails, "
-                "skip this check with --disable_webrtcvad_check")
-    del args.disable_webrtcvad_check
+                "use --no_trim to disable this error message.")
+    del args.no_trim
 
     run_synthesis(args.in_dir, args.out_dir, args.model_dir, modified_hp)
 

--- a/vocoder_preprocess.py
+++ b/vocoder_preprocess.py
@@ -28,6 +28,8 @@ if __name__ == "__main__":
     parser.add_argument("--hparams", default="",
                         help="Hyperparameter overrides as a comma-separated list of name=value "
                              "pairs")
+    parser.add_argument("--disable_webrtcvad_check", action="store_true", help=\
+        "Preprocess audio without the webrtcvad package installed (not recommended).")
     args = parser.parse_args()
     print_args(args, parser)
     modified_hp = hparams.parse(args.hparams)
@@ -37,5 +39,15 @@ if __name__ == "__main__":
     if not hasattr(args, "out_dir"):
         args.out_dir = os.path.join(args.datasets_root, "SV2TTS", "vocoder")
     
+    # Verify webrtcvad is available
+    if not args.disable_webrtcvad_check:
+        try:
+            import webrtcvad
+        except:
+            raise ModuleNotFoundError("Package 'webrtcvad' not found. This package enables "
+                "noise removal and is recommended. Please install and try again. If installation fails, "
+                "skip this check with --disable_webrtcvad_check")
+    del args.disable_webrtcvad_check
+
     run_synthesis(args.in_dir, args.out_dir, args.model_dir, modified_hp)
-    
+


### PR DESCRIPTION
Here is an idea for resolving #375 . I also suggest removing webrtcvad from requirements.txt to make installation easier for Windows users. The training instructions will need to include a step to install webrtcvad if using LibriSpeech or LibriTTS. Since training setup is already manual I find that preferable to including it in requirements.txt and complicating the install for everyone else.