### PR TITLE
Allowing user to select audio device and disabling unsupported devices

### DIFF
--- a/toolbox/__init__.py
+++ b/toolbox/__init__.py
@@ -82,7 +82,8 @@ class Toolbox:
         self.ui.play_button.clicked.connect(func)
         self.ui.stop_button.clicked.connect(self.ui.stop)
         self.ui.record_button.clicked.connect(self.record)
-        
+        self.ui.setup_audio_devices(Synthesizer.sample_rate)
+
         # Generation
         func = lambda: self.synthesize() or self.vocode()
         self.ui.generate_button.clicked.connect(func)

--- a/toolbox/ui.py
+++ b/toolbox/ui.py
@@ -13,7 +13,7 @@ import numpy as np
 from time import sleep
 import umap
 import sys
-from warnings import filterwarnings
+from warnings import filterwarnings, warn
 filterwarnings("ignore")
 
 
@@ -137,14 +137,14 @@ class UI(QDialog):
         self.umap_ax.set_yticks([])
         self.umap_ax.figure.canvas.draw()
 
-    def setup_audio_devices(self,samplerate):
+    def setup_audio_devices(self,sample_rate):
         supported_devices=[]
         for device in sd.query_devices():
             try:
-                sd.check_output_settings(device=device['name'], samplerate=samplerate)
+                sd.check_output_settings(device=device['name'], samplerate=sample_rate)
                 supported_devices.append(device['name'])
             except Exception as e:
-                print("Unsuported device: ",samplerate,"Device: ", device['name'], "\n", e)
+                warn("Unsupported device "+ device['name']+" for the sample rate: "+str(sample_rate)+": "+str(e))
         if len(supported_devices)==0:
             error_dialog = QtWidgets.QErrorMessage()
             error_dialog.showMessage("No supported output audio devices were found! Audio output may not work.")

--- a/toolbox/ui.py
+++ b/toolbox/ui.py
@@ -138,37 +138,37 @@ class UI(QDialog):
         self.umap_ax.figure.canvas.draw()
 
     def setup_audio_devices(self,sample_rate):
-        input_devices=[]
-        output_devices=[]
+        input_devices = []
+        output_devices = []
         for device in sd.query_devices():
             # Check if valid input
             try:
-                sd.check_input_settings(device=device['name'], samplerate=sample_rate)
-                input_devices.append(device['name'])
+                sd.check_input_settings(device=device["name"], samplerate=sample_rate)
+                input_devices.append(device["name"])
             except:
                 pass
 
             # Check if valid output
             try:
-                sd.check_output_settings(device=device['name'], samplerate=sample_rate)
-                output_devices.append(device['name'])
+                sd.check_output_settings(device=device["name"], samplerate=sample_rate)
+                output_devices.append(device["name"])
             except Exception as e:
                 # Log a warning only if the device is not an input
-                if not device['name'] in input_devices:
-                    warn("Unsupported output device "+ device['name']+" for the sample rate: "+str(sample_rate)+": "+str(e))
+                if not device["name"] in input_devices:
+                    warn("Unsupported output device %s for the sample rate: %d \nError: %s" % (device["name"], sample_rate, str(e)))
 
-        if len(input_devices)==0:
+        if len(input_devices) == 0:
             self.log("No audio input device detected. Recording may not work.")
-            self.audio_in_devices_cb.addItems(['None'])
+            self.audio_in_devices_cb.addItems(["None"])
             self.audio_in_devices_cb.setDisabled(True)
         else:
             self.audio_in_devices_cb.clear()
             self.audio_in_devices_cb.addItems(input_devices)
             self.audio_in_devices_cb.currentTextChanged.connect(self.set_audio_device)
 
-        if len(output_devices)==0:
+        if len(output_devices) == 0:
             self.log("No supported output audio devices were found! Audio output may not work.")
-            self.audio_out_devices_cb.addItems(['None'])
+            self.audio_out_devices_cb.addItems(["None"])
             self.audio_out_devices_cb.setDisabled(True)
         else:
             self.audio_out_devices_cb.clear()
@@ -179,11 +179,11 @@ class UI(QDialog):
 
     def set_audio_device(self):
         input_device = self.audio_in_devices_cb.currentText()
-        if input_device == 'None':
+        if input_device == "None":
             input_device = None
         
         output_device = self.audio_out_devices_cb.currentText()
-        if output_device == 'None':
+        if output_device == "None":
             output_device = None
 
         # If None, sounddevice queries portaudio


### PR DESCRIPTION
There can be multiple audio devices and I was actually having an issue on linux where sounddevice was picking my hdmi device as the default which doesn't even support the synthesizer samplerate raising an error ` Invalid sample rate [PaErrorCode -9997]`. 

This filters unsupported devices for the synthesizer samplerate and adds a combobox on the gui to select the desired audio device.