### PR TITLE
Remove tensorflow-gpu from requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You will need the following whether you plan to use the toolbox only or to retra
 
 Run `pip install -r requirements.txt` to install the necessary packages. Additionally you will need [PyTorch](https://pytorch.org/get-started/locally/) (>=1.0.1).
 
-A GPU is mandatory, but you don't necessarily need a high tier GPU if you only want to use the toolbox.
+If you have a GPU, run `pip install -r requirements_gpu.txt` to enable GPU support. A GPU is recommended, but it is not required to use the toolbox.
 
 ### Pretrained models
 Download the latest [here](https://github.com/CorentinJ/Real-Time-Voice-Cloning/wiki/Pretrained-models).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,4 @@
-# each portion of tensorflow is needed
-# core package is for RNN, cpu and gpu are for specific system speed-ups
 tensorflow==1.15
-tensorflow-cpu==1.15
-tensorflow-gpu==1.15
 umap-learn
 visdom
 librosa>=0.5.1

--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -1,0 +1,5 @@
+# This is a list of recommended packages that also enables GPU support.
+# You will also need the packages listed in requirements.txt
+tensorflow-cpu==1.15
+tensorflow-gpu==1.15
+webrtcvad

--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -1,5 +1,5 @@
 # This is a list of recommended packages that also enables GPU support.
 # You will also need the packages listed in requirements.txt
 
-tensorflow-gpu==1.15   # Enables GPU support
+tensorflow-gpu==1.15   # Enables GPU support for synthesizer
 webrtcvad              # Better noise reduction when processing audio files

--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -1,5 +1,4 @@
 # This is a list of recommended packages that also enables GPU support.
 # You will also need the packages listed in requirements.txt
-tensorflow-cpu==1.15
 tensorflow-gpu==1.15
 webrtcvad

--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -1,4 +1,5 @@
 # This is a list of recommended packages that also enables GPU support.
 # You will also need the packages listed in requirements.txt
-tensorflow-gpu==1.15
-webrtcvad
+
+tensorflow-gpu==1.15   # Enables GPU support
+webrtcvad              # Better noise reduction when processing audio files


### PR DESCRIPTION
The situation: `tensorflow-gpu` is not published for mac so `pip install -r requirements.txt` will fail for those users. See #325 . I suggest removing the unnecessary packages tensorflow-cpu and tensorflow-gpu from requirements.txt for maximum compatibility.

At the same time we might want to consider starting another requirements file with suggested packages like webrtcvad, and the removed tensorflow packages. @CorentinJ How do you think we should handle this?