### PR TITLE
Disable the "Load" button if dataset is not specified when launching toolbox

### DIFF
--- a/toolbox/ui.py
+++ b/toolbox/ui.py
@@ -297,6 +297,7 @@ class UI(QDialog):
                 self.utterance_box.setDisabled(True)
                 self.speaker_box.setDisabled(True)
                 self.dataset_box.setDisabled(True)
+                self.browser_load_button.setDisabled(True)
                 return 
             self.repopulate_box(self.dataset_box, datasets, random)
     


### PR DESCRIPTION
Resolves #409 . This is also a common source of confusion for new users who don't use a dataset with the toolbox. They click the "Load" button expecting to get a dialog to load a file, and instead get an exception. Most recently occurred in #407.