### PR TITLE
Print helpful error message if models not found

### DIFF
--- a/demo_cli.py
+++ b/demo_cli.py
@@ -1,5 +1,6 @@
 from encoder.params_model import model_embedding_size as speaker_embedding_size
 from utils.argutils import print_args
+from utils.modelutils import check_model_paths
 from synthesizer.inference import Synthesizer
 from encoder import inference as encoder
 from vocoder import inference as vocoder
@@ -53,12 +54,9 @@ if __name__ == '__main__':
     else:
         print("Using CPU for inference.\n")
     
-    ## Print helpful error message if models are not present
-    if not args.enc_model_fpath.is_file():
-        if not args.syn_model_dir.is_dir():
-            if not args.voc_model_fpath.is_file():
-                print("Error: Model files not found. If needed, download them here: https://github.com/CorentinJ/Real-Time-Voice-Cloning/wiki/Pretrained-models")
-                quit(-1)
+    ## Remind the user to download pretrained models if needed
+    check_model_paths(encoder_path=args.enc_model_fpath, synthesizer_path=args.syn_model_dir,
+                      vocoder_path=args.voc_model_fpath)
     
     ## Load the models one by one.
     print("Preparing the encoder, the synthesizer and the vocoder...")

--- a/demo_cli.py
+++ b/demo_cli.py
@@ -53,6 +53,12 @@ if __name__ == '__main__':
     else:
         print("Using CPU for inference.\n")
     
+    ## Print helpful error message if models are not present
+    if not args.enc_model_fpath.is_file():
+        if not args.syn_model_dir.is_dir():
+            if not args.voc_model_fpath.is_file():
+                print("Error: Model files not found. If needed, download them here: https://github.com/CorentinJ/Real-Time-Voice-Cloning/wiki/Pretrained-models")
+                quit(-1)
     
     ## Load the models one by one.
     print("Preparing the encoder, the synthesizer and the vocoder...")

--- a/demo_toolbox.py
+++ b/demo_toolbox.py
@@ -26,8 +26,14 @@ if __name__ == '__main__':
         "If True, the memory used by the synthesizer will be freed after each use. Adds large "
         "overhead but allows to save some GPU memory for lower-end GPUs.")
     args = parser.parse_args()
+    print_args(args, parser)
+
+    ## Print helpful error message if models are not present
+    if not args.enc_models_dir.is_dir():
+        if not args.syn_models_dir.is_dir():
+            if not args.voc_models_dir.is_dir():
+                print("Error: Model files not found. If needed, download them here: https://github.com/CorentinJ/Real-Time-Voice-Cloning/wiki/Pretrained-models")
+                quit(-1)
 
     # Launch the toolbox
-    print_args(args, parser)
-    Toolbox(**vars(args))
-    
+    Toolbox(**vars(args))    

--- a/demo_toolbox.py
+++ b/demo_toolbox.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from toolbox import Toolbox
 from utils.argutils import print_args
+from utils.modelutils import check_model_paths
 import argparse
 
 
@@ -28,12 +29,9 @@ if __name__ == '__main__':
     args = parser.parse_args()
     print_args(args, parser)
 
-    ## Print helpful error message if models are not present
-    if not args.enc_models_dir.is_dir():
-        if not args.syn_models_dir.is_dir():
-            if not args.voc_models_dir.is_dir():
-                print("Error: Model files not found. If needed, download them here: https://github.com/CorentinJ/Real-Time-Voice-Cloning/wiki/Pretrained-models")
-                quit(-1)
+    ## Remind the user to download pretrained models if needed
+    check_model_paths(encoder_path=args.enc_models_dir, synthesizer_path=args.syn_models_dir,
+                      vocoder_path=args.voc_models_dir)
 
     # Launch the toolbox
     Toolbox(**vars(args))    

--- a/utils/modelutils.py
+++ b/utils/modelutils.py
@@ -10,6 +10,6 @@ def check_model_paths(encoder_path: Path, synthesizer_path: Path, vocoder_path: 
         return
 
     # If none of the paths exist, remind the user to download models if needed
-    print("Error: Model files not found. If needed, download them here: ")
+    print("Error: Model files not found. If needed, download them here:")
     print("https://github.com/CorentinJ/Real-Time-Voice-Cloning/wiki/Pretrained-models\n")
     quit(-1)

--- a/utils/modelutils.py
+++ b/utils/modelutils.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+def check_model_paths(encoder_path: Path, synthesizer_path: Path, vocoder_path: Path):
+    # This function tests the model paths and makes sure at least one is valid.
+    if encoder_path.is_file() or encoder_path.is_dir():
+        return
+    if synthesizer_path.is_file() or synthesizer_path.is_dir():
+        return
+    if vocoder_path.is_file() or vocoder_path.is_dir():
+        return
+
+    # If none of the paths exist, remind the user to download models if needed
+    print("Error: Model files not found. If needed, download them here: ")
+    print("https://github.com/CorentinJ/Real-Time-Voice-Cloning/wiki/Pretrained-models\n")
+    quit(-1)


### PR DESCRIPTION
A lot of people don't know what to do with the "No encoder models found in encoder/saved_models" error message, leading to issues like #387, #393 and #412.

We just updated README.md to emphasize that downloading the pretrained models is part of the setup process, in #414 . However, I would also like to print a helpful error message when no models are found. This will allow the user to fix their own problem.