### PR TITLE
Catch PortAudioError exception so it is not fatal

### DIFF
--- a/demo_cli.py
+++ b/demo_cli.py
@@ -166,8 +166,14 @@ if __name__ == '__main__':
             
             # Play the audio (non-blocking)
             if not args.no_sound:
-                sd.stop()
-                sd.play(generated_wav, synthesizer.sample_rate)
+                try:
+                    sd.stop()
+                    sd.play(generated_wav, synthesizer.sample_rate)
+                except sd.PortAudioError as e:
+                    print("\nCaught exception: %s" % repr(e))
+                    print("Continuing without audio playback. Suppress this message with the \"--no_sound\" flag.\n")
+                except:
+                    raise
                 
             # Save it on the disk
             filename = "demo_output_%02d.wav" % num_generated


### PR DESCRIPTION
Allow demo_cli.py to continue even if it is unable to play sound, when the "--no_sound" flag is not present.
1. Some users may not immediately see "--no_sound" as a solution when they see the exception (problem: https://github.com/CorentinJ/Real-Time-Voice-Cloning/issues/214#issuecomment-568201938)
2. The exception is currently fatal which forces the user to start from the beginning. On CPU, the configuration test and waveform generation are quite slow. This makes it annoying to rediscover this issue from time to time on systems that do not support audio output.

Solution:
1. When PortAudioError is caught, display the message and allow demo_cli.py to continue to the next step of saving the wav
2. All other errors continue to be raised as normal