### PR TITLE
Low memory inference fix

### DIFF
--- a/synthesizer/inference.py
+++ b/synthesizer/inference.py
@@ -2,6 +2,7 @@ from synthesizer.tacotron2 import Tacotron2
 from synthesizer.hparams import hparams
 from multiprocess.pool import Pool  # You're free to use either one
 #from multiprocessing import Pool   # 
+from multiprocess.context import SpawnContext
 from synthesizer import audio
 from pathlib import Path
 from typing import Union, List
@@ -97,7 +98,7 @@ class Synthesizer:
             # Low memory inference mode: load the model upon every request. The model has to be 
             # loaded in a separate process to be able to release GPU memory (a simple workaround 
             # to tensorflow's intricacies)
-            specs, alignments = Pool(1).starmap(Synthesizer._one_shot_synthesize_spectrograms, 
+            specs, alignments = Pool(1, context=SpawnContext()).starmap(Synthesizer._one_shot_synthesize_spectrograms,
                                                 [(self.checkpoint_fpath, embeddings, texts)])[0]
     
         return (specs, alignments) if return_alignments else specs

--- a/synthesizer/inference.py
+++ b/synthesizer/inference.py
@@ -99,15 +99,15 @@ class Synthesizer:
             # loaded in a separate process to be able to release GPU memory (a simple workaround 
             # to tensorflow's intricacies)
             specs, alignments = Pool(1, context=SpawnContext()).starmap(Synthesizer._one_shot_synthesize_spectrograms,
-                                                [(self.checkpoint_fpath, embeddings, texts)])[0]
+                                                [(self.checkpoint_fpath, embeddings, texts, self._seed)])[0]
     
         return (specs, alignments) if return_alignments else specs
 
     @staticmethod
-    def _one_shot_synthesize_spectrograms(checkpoint_fpath, embeddings, texts):
+    def _one_shot_synthesize_spectrograms(checkpoint_fpath, embeddings, texts, seed):
         # Load the model and forward the inputs
         tf.compat.v1.reset_default_graph()
-        model = Tacotron2(checkpoint_fpath, hparams, seed=self._seed)
+        model = Tacotron2(checkpoint_fpath, hparams, seed=seed)
         specs, alignments = model.my_synthesize(embeddings, texts)
         
         # Detach the outputs (not doing so will cause the process to hang)


### PR DESCRIPTION
Resolves two separate issues:
1. Use spawned workers instead of forked workers to resolve `CUDA_NOT_INITIALIZED_ERROR` (closes #36) 
2. Passes seed to low_mem inference correctly, and in a way that does not require tensorflow to be pickled (closes #491, #529, #536)

Requesting @mineLdiver to download the [`491_fix_lowmem_seed`](https://github.com/blue-fish/Real-Time-Voice-Cloning/tree/491_fix_lowmem_seed) branch of my fork and test these changes to make sure they work.