### PR TITLE
Change order of matplotlib imports (resolves #504)

### DIFF
--- a/toolbox/ui.py
+++ b/toolbox/ui.py
@@ -1,3 +1,4 @@
+import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from PyQt5.QtCore import Qt, QStringListModel
@@ -8,7 +9,6 @@ from pathlib import Path
 from typing import List, Set
 import sounddevice as sd
 import soundfile as sf
-import matplotlib.pyplot as plt
 import numpy as np
 # from sklearn.manifold import TSNE         # You can try with TSNE if you like, I prefer UMAP 
 from time import sleep


### PR DESCRIPTION
Resolves the issue with the toolbox crashing on startup due to matplotlib error. While this has been fixed in matplotlib 3.3.2, we don't have full support for that version yet (see #455). I recommend applying this workaround for better compatibility.