### PR TITLE
Update instructions for obtaining pretrained models

### DIFF
--- a/utils/modelutils.py
+++ b/utils/modelutils.py
@@ -10,6 +10,6 @@ def check_model_paths(encoder_path: Path, synthesizer_path: Path, vocoder_path: 
         return
 
     # If none of the paths exist, remind the user to download models if needed
-    print("Error: Model files not found. If needed, download them here:")
+    print("Error: Model files not found. Follow these instructions to get and install the models:")
     print("https://github.com/CorentinJ/Real-Time-Voice-Cloning/wiki/Pretrained-models\n")
     quit(-1)


### PR DESCRIPTION
The error message is confusing users (see #463, #476, #482, #494, #560). This is two-part update to improve the situation.

1. Update wording of error message to explain that the models need to be installed
2. Add detail to [pretrained models](https://github.com/CorentinJ/Real-Time-Voice-Cloning/wiki/Pretrained-models) wiki page to explain where the toolbox is expecting to find model files.