### PR TITLE
Minor documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Before you download any dataset, you can begin by testing your configuration wit
 If all tests pass, you're good to go.
 
 ### 4. (Optional) Download Datasets
-For playing with the toolbox alone, I only recommend downloading [`LibriSpeech/train-clean-100`](http://www.openslr.org/resources/12/train-clean-100.tar.gz). Extract the contents as `<datasets_root>/LibriSpeech/train-clean-100` where `<datasets_root>` is a directory of your choosing. Other datasets are supported in the toolbox, see [here](https://github.com/CorentinJ/Real-Time-Voice-Cloning/wiki/Training#datasets). You're free not to download any dataset, but then you will need your own data as audio files or you will have to record it with the toolbox.
+For playing with the toolbox alone, I only recommend downloading [`LibriSpeech/train-clean-100`](https://www.openslr.org/resources/12/train-clean-100.tar.gz). Extract the contents as `<datasets_root>/LibriSpeech/train-clean-100` where `<datasets_root>` is a directory of your choosing. Other datasets are supported in the toolbox, see [here](https://github.com/CorentinJ/Real-Time-Voice-Cloning/wiki/Training#datasets). You're free not to download any dataset, but then you will need your own data as audio files or you will have to record it with the toolbox.
 
 ### 5. Launch the Toolbox
 You can then try the toolbox:

--- a/demo_toolbox.py
+++ b/demo_toolbox.py
@@ -13,10 +13,7 @@ if __name__ == '__main__':
     
     parser.add_argument("-d", "--datasets_root", type=Path, help= \
         "Path to the directory containing your datasets. See toolbox/__init__.py for a list of "
-        "supported datasets. You can add your own data by created a directory named UserAudio "
-        "in your datasets root. Supported formats are mp3, flac, wav and m4a. Each speaker should "
-        "be inside a directory, e.g. <datasets_root>/UserAudio/speaker_01/audio_01.wav.",
-                        default=None)
+        "supported datasets.", default=None)
     parser.add_argument("-e", "--enc_models_dir", type=Path, default="encoder/saved_models", 
                         help="Directory containing saved encoder models")
     parser.add_argument("-s", "--syn_models_dir", type=Path, default="synthesizer/saved_models", 


### PR DESCRIPTION
1. Change LibriSpeech train-clean-100 download link to https (resolves #561)
2. Remove reference to deleted UserAudio feature (see https://github.com/CorentinJ/Real-Time-Voice-Cloning/pull/527#issuecomment-693227456 ). If instead, you would like to bring back that feature then we could consider merging #527.