### PR TITLE
Librosa 0.8.0 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 tensorflow==1.15
 umap-learn
 visdom
-librosa>=0.5.1
+librosa>=0.8.0
 matplotlib>=2.0.2
 numpy>=1.14.0
 scipy>=1.0.0
@@ -12,4 +12,4 @@ Unidecode
 inflect
 PyQt5
 multiprocess
-numba==0.48
+numba

--- a/synthesizer/audio.py
+++ b/synthesizer/audio.py
@@ -4,6 +4,7 @@ import numpy as np
 import tensorflow as tf
 from scipy import signal
 from scipy.io import wavfile
+import soundfile as sf
 
 
 def load_wav(path, sr):
@@ -15,7 +16,7 @@ def save_wav(wav, path, sr):
     wavfile.write(path, sr, wav.astype(np.int16))
 
 def save_wavenet_wav(wav, path, sr):
-    librosa.output.write_wav(path, wav, sr=sr)
+    sf.write(path, wav.astype(np.float32), sr)
 
 def preemphasis(wav, k, preemphasize=True):
     if preemphasize:

--- a/vocoder/audio.py
+++ b/vocoder/audio.py
@@ -3,6 +3,7 @@ import numpy as np
 import librosa
 import vocoder.hparams as hp
 from scipy.signal import lfilter
+import soundfile as sf
 
 
 def label_2_float(x, bits) :
@@ -20,7 +21,7 @@ def load_wav(path) :
 
 
 def save_wav(x, path) :
-    librosa.output.write_wav(path, x.astype(np.float32), sr=hp.sample_rate)
+    sf.write(path, x.astype(np.float32), hp.sample_rate)
 
 
 def split_signal(x) :


### PR DESCRIPTION
Librosa 0.8 removed the deprecated `librosa.output.write_wav` function. This PR replaces it with `soundfile.write` as recommended in the librosa documentation ([link](https://librosa.org/doc/0.7.2/generated/librosa.output.write_wav.html)).

Tested: demo_cli.py, demo_toolbox.py, vocoder_train.py