### PR TITLE
Matplotlib colorbar update

### DIFF
--- a/encoder/inference.py
+++ b/encoder/inference.py
@@ -172,8 +172,7 @@ def plot_embedding_as_heatmap(embed, ax=None, title="", shape=None, color_range=
     cmap = cm.get_cmap()
     mappable = ax.imshow(embed, cmap=cmap)
     cbar = plt.colorbar(mappable, ax=ax, fraction=0.046, pad=0.04)
-    norm = mcolors.Normalize()
-    sm = cm.ScalarMappable(cmap=cmap, norm=norm)
+    sm = cm.ScalarMappable(cmap=cmap)
     sm.set_clim(*color_range)
     
     ax.set_xticks([]), ax.set_yticks([])

--- a/encoder/inference.py
+++ b/encoder/inference.py
@@ -4,6 +4,7 @@ from encoder.audio import preprocess_wav   # We want to expose this function fro
 from matplotlib import cm
 from encoder import audio
 from pathlib import Path
+import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
@@ -171,7 +172,9 @@ def plot_embedding_as_heatmap(embed, ax=None, title="", shape=None, color_range=
     cmap = cm.get_cmap()
     mappable = ax.imshow(embed, cmap=cmap)
     cbar = plt.colorbar(mappable, ax=ax, fraction=0.046, pad=0.04)
-    cbar.set_clim(*color_range)
+    norm = mcolors.Normalize()
+    sm = cm.ScalarMappable(cmap=cmap, norm=norm)
+    sm.set_clim(*color_range)
     
     ax.set_xticks([]), ax.set_yticks([])
     ax.set_title(title)

--- a/encoder/inference.py
+++ b/encoder/inference.py
@@ -4,7 +4,6 @@ from encoder.audio import preprocess_wav   # We want to expose this function fro
 from matplotlib import cm
 from encoder import audio
 from pathlib import Path
-import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
 import torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ tensorflow==1.15
 umap-learn
 visdom
 librosa>=0.8.0
-matplotlib>=2.0.2
+matplotlib>=3.3.0
 numpy>=1.14.0
 scipy>=1.0.0
 tqdm


### PR DESCRIPTION
In matplotlib 3.3.0, `colorbar.set_clim()` was removed. This causes the toolbox to break when plotting the embeds. This PR updates the code to use `ScalarMappable.set_clim()` as suggested in the [matplotlib 3.3.0 API change list](https://github.com/matplotlib/matplotlib/blob/a8831d57207db5e9bf681e30810ce0ea146f4a31/doc/api/prev_api_changes/api_changes_3.3.0/removals.rst).

Tested: demo_toolbox.py
Resolves: #455