### PR TITLE
Add support for W&B logging

### DIFF
--- a/encoder/train.py
+++ b/encoder/train.py
@@ -10,9 +10,6 @@ import torch
 import wandb
 
 
-
-
-
 def sync(device: torch.device):
     # For correct profiling (cuda operations are async)
     if device.type == "cuda":
@@ -107,9 +104,7 @@ def train(run_id: str, clean_data_root: Path, models_dir: Path, umap_every: int,
         # Update visualizations
         # learning_rate = optimizer.param_groups[0]["lr"]
         vis.update(loss.item(), eer, step)
-        
- 
-            
+                
         # Draw projections and save them to the backup folder
         if umap_every != 0 and step % umap_every == 0:
             print("Drawing and saving projections (step %d)" % step)
@@ -118,7 +113,6 @@ def train(run_id: str, clean_data_root: Path, models_dir: Path, umap_every: int,
             embeds = embeds.detach().cpu().numpy()
             vis.draw_projections(embeds, utterances_per_speaker, step, projection_fpath)
             vis.save()
-
 
         # Overwrite the latest version of the model
         if save_every != 0 and step % save_every == 0:

--- a/encoder/visualizations.py
+++ b/encoder/visualizations.py
@@ -64,8 +64,6 @@ class Visualizations:
         self.implementation_string = ""
         
     def log_params(self):
-        if self.disabled:
-            return 
         from encoder import params_data
         from encoder import params_model
         param_string = "<b>Model parameters</b>:<br>"
@@ -81,7 +79,8 @@ class Visualizations:
             param_string += "\t%s: %s<br>" % (param_name, value)
             if wandb.run:
                 wandb.config.update({param_name: value})
-        self.vis.text(param_string, opts={"title": "Parameters"})
+        if not self.disabled: 
+            self.vis.text(param_string, opts={"title": "Parameters"})
         
     def log_dataset(self, dataset: SpeakerVerificationDataset):
         if self.disabled:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ inflect
 PyQt5
 multiprocess
 numba==0.48
+wandb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 tensorflow==1.15
 umap-learn
 visdom
-librosa>=0.5.1
-matplotlib>=2.0.2
+librosa>=0.8.0
+matplotlib>=3.3.0
 numpy>=1.14.0
 scipy>=1.0.0
 tqdm
@@ -12,5 +12,5 @@ Unidecode
 inflect
 PyQt5
 multiprocess
-numba==0.48
+numba
 wandb

--- a/synthesizer/train.py
+++ b/synthesizer/train.py
@@ -402,9 +402,9 @@ def train(log_dir, args, hparams):
                                           max_len=target_length)
                     if wandb.run:
                         wandb.log({
-                            "Wave from Mel": wandb.Audio(os.path.join(wav_dir, "step-{}-wave-from-mel.wav".format(step))),
-                            "Alignment": wandb.Image(os.path.join(plot_dir, "step-{}-align.png".format(step))),
-                            "Mel Spectrogram": os.path.join(plot_dir, "step-{}-mel-spectrogram.png".format(step))
+                        "Wave from Mel": wandb.Audio(os.path.join(wav_dir, "step-{}-wave-from-mel.wav".format(step))),
+                        "Alignment": wandb.Image(os.path.join(plot_dir, "step-{}-align.png".format(step))),
+                        "Mel Spectrogram": wandb.Image(os.path.join(plot_dir, "step-{}-mel-spectrogram.png".format(step)))
                              })
                     log("Input at step {}: {}".format(step, sequence_to_text(input_seq)))
                 

--- a/synthesizer/train.py
+++ b/synthesizer/train.py
@@ -16,6 +16,7 @@ import wandb
 
 log = infolog.log
 
+
 def add_embedding_stats(summary_writer, embedding_names, paths_to_meta, checkpoint_path):
     # Create tensorboard projector
     config = tf.contrib.tensorboard.plugins.projector.ProjectorConfig()
@@ -36,14 +37,12 @@ def add_train_stats(model, hparams):
     with tf.compat.v1.variable_scope("stats") as scope:
         for i in range(hparams.tacotron_num_gpus):
             tf.compat.v1.summary.histogram("mel_outputs %d" % i, model.tower_mel_outputs[i])
-            tf.compat.v1.summary.histogram("mel_targets %d" % i, model.tower_mel_targets[i])
-                    
+            tf.compat.v1.summary.histogram("mel_targets %d" % i, model.tower_mel_targets[i])            
         tf.compat.v1.summary.scalar("before_loss", model.before_loss)
         tf.compat.v1.summary.scalar("after_loss", model.after_loss)
         
         if hparams.predict_linear:
             tf.compat.v1.summary.scalar("linear_loss", model.linear_loss)
-                
             for i in range(hparams.tacotron_num_gpus):
                 tf.compat.v1.summary.histogram("mel_outputs %d" % i, model.tower_linear_outputs[i])
                 tf.compat.v1.summary.histogram("mel_targets %d" % i, model.tower_linear_targets[i])
@@ -301,7 +300,6 @@ def train(log_dir, args, hparams):
                     audio.save_wav(wav, os.path.join(eval_wav_dir,
                                                      "step-{}-eval-wave-from-mel.wav".format(step)),
                                    sr=hparams.sample_rate)
-                        
                     plot.plot_alignment(align, os.path.join(eval_plot_dir,
                                                             "step-{}-eval-align.png".format(step)),
                                         title="{}, {}, step={}, loss={:.5f}".format("Tacotron",
@@ -382,7 +380,6 @@ def train(log_dir, args, hparams):
                     audio.save_wav(wav,
                                    os.path.join(wav_dir, "step-{}-wave-from-mel.wav".format(step)),
                                    sr=hparams.sample_rate)
-
                     
                     # save alignment plot to disk (control purposes)
                     plot.plot_alignment(alignment,

--- a/vocoder/gen_wavernn.py
+++ b/vocoder/gen_wavernn.py
@@ -1,6 +1,6 @@
 from vocoder.models.fatchord_version import  WaveRNN
 from vocoder.audio import *
-
+import wandb
 
 def gen_testset(model: WaveRNN, test_set, samples, batched, target, overlap, save_path):
     k = model.get_step() // 1000
@@ -28,4 +28,8 @@ def gen_testset(model: WaveRNN, test_set, samples, batched, target, overlap, sav
 
         wav = model.generate(m, batched, target, overlap, hp.mu_law)
         save_wav(wav, save_str)
+        if wandb.run:
+            wandb.log({"target wave": wandb.Audio(str(save_path.joinpath("%dk_steps_%d_target.wav" % (k, i))))})
+            wandb.log({"Generated wave": wandb.Audio(str(save_str))})
+            
 


### PR DESCRIPTION
This PR adds support for wandb logging. The training pipepiline is divided into 3 independent parts that will be grouped together under the name `run_id` provided as argparse argument.
* Here's a [W&B dashboard](https://wandb.ai/cayush/Voice-cloning?workspace=user-cayush) generated using this repo 
* Here's a [W&B report](https://wandb.ai/cayush/Voice-cloning/reports/Real-Time-Voice-Cloning--VmlldzoyOTA0MzM) that takes you through the process of voice cloning using this repo using interactive visualizations, with inputs-inferences comparison side-by-side.
### Dependencies
* Adds 1 dependency - `wandb`

### Example dashboard
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/15766192/97160697-bbedd980-17a2-11eb-8887-8739b4e2192b.gif)
