### PR TITLE
Add exception handling for toolbox audio playback errors

### DIFF
--- a/toolbox/ui.py
+++ b/toolbox/ui.py
@@ -199,8 +199,13 @@ class UI(QDialog):
         sd.default.device = (self.audio_in_device, output_device)
     
     def play(self, wav, sample_rate):
-        sd.stop()
-        sd.play(wav, sample_rate)
+        try:
+            sd.stop()
+            sd.play(wav, sample_rate)
+        except Exception as e:
+            print(e)
+            self.log("Error in audio playback. Try selecting a different audio output device.")
+            self.log("Your device must be connected before you start the toolbox.")
         
     def stop(self):
         sd.stop()


### PR DESCRIPTION
Please see #580 for context.

Some users do not have a valid audio output device, but still wish to save audio files from the toolbox. Currently, a PortAudio exception is raised during failed playback, preventing the vocoded audio from being added to the buffer for export. This PR fixes this problem by adding exception handling for audio playback errors.