### PR TITLE
Pin numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ umap-learn
 visdom
 librosa>=0.8.0
 matplotlib>=3.3.0
-numpy>=1.14.0
+numpy==1.19.3; platform_system == "Windows"
+numpy==1.19.4; platform_system != "Windows"
 scipy>=1.0.0
 tqdm
 sounddevice


### PR DESCRIPTION
Windows and Linux require different versions of numpy due to an unresolved Windows runtime bug. Reported in #596