### PR TITLE
Emphasize error message when model files not found

### DIFF
--- a/utils/modelutils.py
+++ b/utils/modelutils.py
@@ -10,6 +10,8 @@ def check_model_paths(encoder_path: Path, synthesizer_path: Path, vocoder_path: 
         return
 
     # If none of the paths exist, remind the user to download models if needed
+    print("********************************************************************************")
     print("Error: Model files not found. Follow these instructions to get and install the models:")
-    print("https://github.com/CorentinJ/Real-Time-Voice-Cloning/wiki/Pretrained-models\n")
+    print("https://github.com/CorentinJ/Real-Time-Voice-Cloning/wiki/Pretrained-models")
+    print("********************************************************************************\n")
     quit(-1)


### PR DESCRIPTION
Some users are having trouble identifying the problem when the pretrained models are not found (#638, #666). This PR adds some emphasis to draw attention to the error.

The model check feature was originally implemented in #416.

#### Before:
```
Error: Model files not found. Follow these instructions to get and install the models:
https://github.com/CorentinJ/Real-Time-Voice-Cloning/wiki/Pretrained-models
```
#### After:
```
********************************************************************************
Error: Model files not found. Follow these instructions to get and install the models:
https://github.com/CorentinJ/Real-Time-Voice-Cloning/wiki/Pretrained-models
********************************************************************************
```