### PR TITLE
Update synthesizer/train.py, vocoder/train.py, synthesizer/synthesize.py, vocoder_preprocess.py to Allow Vocoder_preprocess to Work (Win10 GPU)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ SV2TTS is a three-stage deep learning framework that allows to create a numerica
 
 **Python 3.6 or 3.7** is needed to run the toolbox.
 
-* Install [PyTorch](https://pytorch.org/get-started/locally/) (>=1.0.1).
+* Install [PyTorch](https://pytorch.org/get-started/locally/) (>=1.1.0).
 * Install [ffmpeg](https://ffmpeg.org/download.html#get-packages).
 * Run `pip install -r requirements.txt` to install the remaining necessary packages.
 

--- a/demo_cli.py
+++ b/demo_cli.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
 
     if args.cpu:
         # Hide GPUs from Pytorch to force CPU processing
-        os.environ["CUDA_VISIBLE_DEVICES"] = ""
+        os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
 
     if not args.no_mp3_support:
         try:

--- a/demo_toolbox.py
+++ b/demo_toolbox.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
 
     if args.cpu:
         # Hide GPUs from Pytorch to force CPU processing
-        os.environ["CUDA_VISIBLE_DEVICES"] = ""
+        os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
     del args.cpu
 
     ## Remind the user to download pretrained models if needed

--- a/synthesizer/synthesize.py
+++ b/synthesizer/synthesize.py
@@ -8,14 +8,12 @@ from synthesizer.utils.symbols import symbols
 import numpy as np
 from pathlib import Path
 from tqdm import tqdm
-#@tomcattwo added below line to fix Win10 pickle error per issue #669 and  blue-fish/Real-Time-Voice-Cloning@89a9964
 import platform
 
 def run_synthesis(in_dir, out_dir, model_dir, hparams):
     # This generates ground truth-aligned mels for vocoder training
     synth_dir = Path(out_dir).joinpath("mels_gta")
     synth_dir.mkdir(exist_ok=True)
-    #@tomcattwo edited below line to remove argument "hparams" from "hparams_debug_string(hparams)" to fix error when running vocoder_preprocess (issue #833)
     print(hparams_debug_string())
 
     # Check for GPU
@@ -62,7 +60,6 @@ def run_synthesis(in_dir, out_dir, model_dir, hparams):
     mel_dir = in_dir.joinpath("mels")
     embed_dir = in_dir.joinpath("embeds")
 
-    #@tomcattwo edited line 67 to add "hparams" positional argument per issue #833 and line 69 to fix Win10 pickle issue per issue#669 and blue-fish/Real-Time-Voice-Cloning@89a9964
     dataset = SynthesizerDataset(metadata_fpath, mel_dir, embed_dir, hparams)
     data_loader = DataLoader(dataset,
                              collate_fn=lambda batch: collate_synthesizer(batch, r, hparams),
@@ -80,7 +77,6 @@ def run_synthesis(in_dir, out_dir, model_dir, hparams):
             embeds = embeds.to(device)
 
             # Parallelize model onto GPUS using workaround due to python bug
-            #@tomcattwo edited line 86 per @blue-fish recommendation in issue #833 to allow vocoder_preprocess.py to run properly
             if device.type == "cuda" and torch.cuda.device_count() > 1:
                 _, mels_out, _ = data_parallel_workaround(model, texts, mels, embeds)
             else:

--- a/synthesizer/synthesize.py
+++ b/synthesizer/synthesize.py
@@ -81,7 +81,7 @@ def run_synthesis(in_dir, out_dir, model_dir, hparams):
                 _, mels_out, _ = data_parallel_workaround(model, texts, mels, embeds)
             else:
                 _, mels_out, _, _ = model(texts, mels, embeds)
-    
+
             for j, k in enumerate(idx):
                 # Note: outputs mel-spectrogram files and target ones have same names, just different folders
                 mel_filename = Path(synth_dir).joinpath(dataset.metadata[k][1])

--- a/synthesizer/train.py
+++ b/synthesizer/train.py
@@ -267,5 +267,3 @@ def eval_model(attention, mel_prediction, target_spectrogram, input_seq, step,
                      target_spectrogram=target_spectrogram,
                      max_len=target_spectrogram.size // hparams.num_mels)
     print("Input at step {}: {}".format(step, sequence_to_text(input_seq)))
-
-    

--- a/synthesizer/train.py
+++ b/synthesizer/train.py
@@ -15,6 +15,8 @@ import numpy as np
 from pathlib import Path
 import sys
 import time
+#tomcattwo added below line per issue #669 and blue-fish/Real-Time-Voice-Cloning@89a9964 to fix Win10 pickle issue
+import platform
 
 
 def np_now(x: torch.Tensor): return x.detach().cpu().numpy()
@@ -142,11 +144,12 @@ def train(run_id: str, syn_dir: str, models_dir: str, save_every: int,
 
         for p in optimizer.param_groups:
             p["lr"] = lr
-
+            
+#tomcattwo changed line 152 below per issue #669 and blue-fish/Real-Time-Voice-Cloning@89a9964 to fix Win10 pickle issue
         data_loader = DataLoader(dataset,
                                  collate_fn=lambda batch: collate_synthesizer(batch, r, hparams),
                                  batch_size=batch_size,
-                                 num_workers=2,
+                                 num_workers=2 if platform.system() != "Windows" else 0,
                                  shuffle=True,
                                  pin_memory=True)
 

--- a/synthesizer/train.py
+++ b/synthesizer/train.py
@@ -143,7 +143,7 @@ def train(run_id: str, syn_dir: str, models_dir: str, save_every: int,
 
         for p in optimizer.param_groups:
             p["lr"] = lr
-            
+
         data_loader = DataLoader(dataset,
                                  collate_fn=lambda batch: collate_synthesizer(batch, r, hparams),
                                  batch_size=batch_size,

--- a/synthesizer/train.py
+++ b/synthesizer/train.py
@@ -267,3 +267,5 @@ def eval_model(attention, mel_prediction, target_spectrogram, input_seq, step,
                      target_spectrogram=target_spectrogram,
                      max_len=target_spectrogram.size // hparams.num_mels)
     print("Input at step {}: {}".format(step, sequence_to_text(input_seq)))
+
+    

--- a/synthesizer/train.py
+++ b/synthesizer/train.py
@@ -15,7 +15,6 @@ import numpy as np
 from pathlib import Path
 import sys
 import time
-#tomcattwo added below line per issue #669 and blue-fish/Real-Time-Voice-Cloning@89a9964 to fix Win10 pickle issue
 import platform
 
 
@@ -145,7 +144,6 @@ def train(run_id: str, syn_dir: str, models_dir: str, save_every: int,
         for p in optimizer.param_groups:
             p["lr"] = lr
             
-#tomcattwo changed line 152 below per issue #669 and blue-fish/Real-Time-Voice-Cloning@89a9964 to fix Win10 pickle issue
         data_loader = DataLoader(dataset,
                                  collate_fn=lambda batch: collate_synthesizer(batch, r, hparams),
                                  batch_size=batch_size,

--- a/vocoder/train.py
+++ b/vocoder/train.py
@@ -11,7 +11,8 @@ import vocoder.hparams as hp
 import numpy as np
 import time
 import torch
-
+#tomcattwo added line 15 per issue #669 and blue-fish/Real-Time-Voice-Cloning@89a9964 to fix Win10 pickle issue.
+import platform
 
 def train(run_id: str, syn_dir: Path, voc_dir: Path, models_dir: Path, ground_truth: bool,
           save_every: int, backup_every: int, force_restart: bool):
@@ -74,12 +75,13 @@ def train(run_id: str, syn_dir: Path, voc_dir: Path, models_dir: Path, ground_tr
     simple_table([('Batch size', hp.voc_batch_size),
                   ('LR', hp.voc_lr),
                   ('Sequence Len', hp.voc_seq_len)])
-    
+          
+    #tomcattwo edited line 84 below per issue #669 and blue-fish/Real-Time-Voice-Cloning@89a9964 to fix Win10 pickle issue.
     for epoch in range(1, 350):
         data_loader = DataLoader(dataset,
                                  collate_fn=collate_vocoder,
                                  batch_size=hp.voc_batch_size,
-                                 num_workers=2,
+                                 num_workers=2 if platform.system() != "Windows" else 0,
                                  shuffle=True,
                                  pin_memory=True)
         start = time.time()

--- a/vocoder/train.py
+++ b/vocoder/train.py
@@ -74,7 +74,7 @@ def train(run_id: str, syn_dir: Path, voc_dir: Path, models_dir: Path, ground_tr
     simple_table([('Batch size', hp.voc_batch_size),
                   ('LR', hp.voc_lr),
                   ('Sequence Len', hp.voc_seq_len)])
-          
+
     for epoch in range(1, 350):
         data_loader = DataLoader(dataset,
                                  collate_fn=collate_vocoder,

--- a/vocoder/train.py
+++ b/vocoder/train.py
@@ -11,7 +11,6 @@ import vocoder.hparams as hp
 import numpy as np
 import time
 import torch
-#tomcattwo added line 15 per issue #669 and blue-fish/Real-Time-Voice-Cloning@89a9964 to fix Win10 pickle issue.
 import platform
 
 def train(run_id: str, syn_dir: Path, voc_dir: Path, models_dir: Path, ground_truth: bool,
@@ -76,7 +75,6 @@ def train(run_id: str, syn_dir: Path, voc_dir: Path, models_dir: Path, ground_tr
                   ('LR', hp.voc_lr),
                   ('Sequence Len', hp.voc_seq_len)])
           
-    #tomcattwo edited line 84 below per issue #669 and blue-fish/Real-Time-Voice-Cloning@89a9964 to fix Win10 pickle issue.
     for epoch in range(1, 350):
         data_loader = DataLoader(dataset,
                                  collate_fn=collate_vocoder,

--- a/vocoder/train.py
+++ b/vocoder/train.py
@@ -74,7 +74,7 @@ def train(run_id: str, syn_dir: Path, voc_dir: Path, models_dir: Path, ground_tr
     simple_table([('Batch size', hp.voc_batch_size),
                   ('LR', hp.voc_lr),
                   ('Sequence Len', hp.voc_seq_len)])
-
+    
     for epoch in range(1, 350):
         data_loader = DataLoader(dataset,
                                  collate_fn=collate_vocoder,

--- a/vocoder_preprocess.py
+++ b/vocoder_preprocess.py
@@ -43,7 +43,6 @@ if __name__ == "__main__":
 
     if args.cpu:
         # Hide GPUs from Pytorch to force CPU processing
-        #@tomcattwo changed line 47 per recommendation by @blue-fish in issue #833; allows --cpu argument to be properly recognized
         os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
     
     # Verify webrtcvad is available

--- a/vocoder_preprocess.py
+++ b/vocoder_preprocess.py
@@ -43,7 +43,8 @@ if __name__ == "__main__":
 
     if args.cpu:
         # Hide GPUs from Pytorch to force CPU processing
-        os.environ["CUDA_VISIBLE_DEVICES"] = ""
+        #@tomcattwo changed line 47 per recommendation by @blue-fish in issue #833; allows --cpu argument to be properly recognized
+        os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
     
     # Verify webrtcvad is available
     if not args.no_trim:


### PR DESCRIPTION
Pull requested by @blue-fish 
@tomcattwo edited synthesizer/train.py per issue #669 and blue-fish/Real-Time-Voice-Cloning@89a9964 to fix Win10 pickle issue.
This will allow Windows users using a GPU to properly run synthesizer training.