### PR TITLE
Ensure bare exception statements are raised

### DIFF
--- a/vocoder/models/fatchord_version.py
+++ b/vocoder/models/fatchord_version.py
@@ -97,7 +97,7 @@ class WaveRNN(nn.Module):
         elif self.mode == 'MOL' :
             self.n_classes = 30
         else :
-            RuntimeError("Unknown model mode value - ", self.mode)
+            raise RuntimeError("Unknown model mode value - ", self.mode)
 
         self.rnn_dims = rnn_dims
         self.aux_dims = res_out_dims // 4


### PR DESCRIPTION
This codemod fixes cases where an exception is referenced by itself in a statement without being raised. This most likely indicates a bug: you probably meant to actually raise the exception. 

Our changes look something like this:
```diff
try:
-   ValueError
+   raise ValueError
except:
    pass
```

<details>
  <summary>More reading</summary>

  * [https://docs.python.org/3/tutorial/errors.html#raising-exceptions](https://docs.python.org/3/tutorial/errors.html#raising-exceptions)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/exception-without-raise](https://docs.pixee.ai/codemods/python/pixee_python_exception-without-raise)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2FReal-Time-Voice-Cloning%7Ca7d3cdca589835f4de223638da4b261d1138b32c)

<!--{"type":"DRIP","codemod":"pixee:python/exception-without-raise"}-->